### PR TITLE
Node ids

### DIFF
--- a/etc_prometheus/prometheus.yml
+++ b/etc_prometheus/prometheus.yml
@@ -9,7 +9,7 @@ alerting:
 global: 
   evaluation_interval: 15s
   scrape_interval: 60s
-  scrape_timeout: 50s
+  scrape_timeout: 30s
 rule_files: 
   -
     rules.yml
@@ -35,3 +35,19 @@ scrape_configs:
       - 
         targets: 
           - "grafana:3000"
+  - 
+    job_name: loki
+    scrape_interval: 15s
+    scrape_timeout: 5s
+    static_configs: 
+      - 
+        targets: 
+          - "loki:3100"
+  - 
+    job_name: alertmanager
+    scrape_interval: 15s
+    scrape_timeout: 5s
+    static_configs: 
+      - 
+        targets: 
+          - "loki:9093"

--- a/export/collector.py
+++ b/export/collector.py
@@ -250,22 +250,53 @@ class wekaCollector(object):
             yield GaugeMetricFamily('weka_collect_seconds', 'Total Time spent in Prometheus collect', value=elapsed)
             #weka_collect_gauge = GaugeMetricFamily('weka_collect_seconds', 'Total Time spent in Prometheus collect')
             #weka_collect_gauge.add_metric(labels={}, value=elapsed)
-            log.info(f"status returned. total time = {elapsed}")
+            log.info(f"stats returned. total time = {elapsed}")
 
     # runs in a thread, so args comes in as a dict
     def call_api( self, cluster, metric, category, args ):
         method = args['method']
         parms = args['parms']
-        log.debug(f"method={method}, parms={parms}")
+        #log.debug(f"method={method}, parms={parms}")
+
+        #log.error(f"calling {cluster.name} API with {method} {parms}")
+        data_returned = cluster.call_api( method=method, parms=parms )
+
+        if category != None and not category in self.clusterdata[str(cluster)]:
+            self.clusterdata[str(cluster)][category] = {}
+
+        if len(data_returned) == 0:
+            return
+
         if category == None:
-            self.clusterdata[str(cluster)][metric] = cluster.call_api( method=method, parms=parms )
+            #log.error(f"{type(data_returned)} {data_returned}")
+            if metric not in self.clusterdata[str(cluster)]:
+                if type(data_returned) == list:
+                    self.clusterdata[str(cluster)][metric] = []
+                else:
+                    self.clusterdata[str(cluster)][metric] = {}
+
+            if type(data_returned) == list:
+                self.clusterdata[str(cluster)][metric] += data_returned
+            else:
+                self.clusterdata[str(cluster)][metric].update(data_returned)
+
         else:
             #print( json.dumps( self.clusterdata, indent=4, sort_keys=True ))
             #log.debug( self.clusterdata[str(cluster)].keys() )
-            if not category in self.clusterdata[str(cluster)]:
-                self.clusterdata[str(cluster)][category] = {}
-            self.clusterdata[str(cluster)][category][metric] = cluster.call_api( method=method, parms=parms )
-        
+            #if not category in self.clusterdata[str(cluster)]:
+            #    self.clusterdata[str(cluster)][category] = {}
+            if metric not in self.clusterdata[str(cluster)][category]:
+                if type(data_returned) == list:
+                    self.clusterdata[str(cluster)][category][metric] = []
+                else:
+                    self.clusterdata[str(cluster)][category][metric] = {}
+
+            if type(data_returned) == list:
+                self.clusterdata[str(cluster)][category][metric] += data_returned
+            else:
+                self.clusterdata[str(cluster)][category][metric].update(data_returned)
+
+
 
     # start here
     #
@@ -278,6 +309,7 @@ class wekaCollector(object):
     def gather( self, cluster ):
         start_time = time.time()
         log.info( "gathering weka data from cluster {}".format(str(cluster)) )
+
 
         # re-initialize wekadata so changes in the cluster don't leave behind strange things (hosts/nodes that no longer exist, etc)
         wekadata={}
@@ -313,11 +345,18 @@ class wekaCollector(object):
         # clear old maps, if any - if nodes come/go this can get funky with old data, so re-create it every time
         weka_maps = { "node-host": {}, "node-role": {}, "host-role": {} }       # initial state of maps
 
+        #backend_nodes = []
+        #client_nodes = []
         # populate maps
         try:
             for node in wekadata["nodeList"]:
                 weka_maps["node-host"][node["node_id"]] = node["hostname"]
                 weka_maps["node-role"][node["node_id"]] = node["roles"]    # note - this is a list
+                #nid = int(node["node_id"].split('<')[1].split('>')[0]) # make nodeid numeric
+                #if node["mode"] == "backend":
+                #    backend_nodes.append(nid)
+                #else:
+                #    client_nodes.append(nid)
             for host in wekadata["hostList"]:
                 if host["mode"] == "backend":
                     weka_maps["host-role"][host["hostname"]] = "server"
@@ -330,17 +369,61 @@ class wekaCollector(object):
             log.error( "error building maps. Aborting data gather from cluster {}".format(str(cluster)) )
             return
 
+        #log.error(f"backend nodes: {backend_nodes}")
+        #log.error(f"client nodes: {client_nodes}")
+
         log.info(f"Cluster {cluster} Using {cluster.sizeof()} hosts")
         thread_runner = simul_threads(cluster.sizeof())   # up the server count - so 1 thread per server in the cluster
         #thread_runner = simul_threads(50)  # testing
 
+        # be simplistic at first... let's just gather on a subset of nodes each query
+        #all_nodes = backend_nodes + client_nodes    # concat both lists
+
+        node_maps = { "FRONTEND": [], "COMPUTE": [], "DRIVES": [], "MANAGEMENT": [] }       # initial state of maps
+
+        #log.error(f'{weka_maps["node-role"]}')
+
+        for node in weka_maps["node-role"]: # node == "NodeId<xx>"
+            for role in weka_maps['node-role'][node]:
+                nid = int(node.split('<')[1].split('>')[0]) # make nodeid numeric
+                node_maps[role].append(nid)
+
+        #log.error(f"{cluster.name} {node_maps}")
+
+        # find a better place to define this... for now here is good (vince)
+        category_nodetypes = { 
+                'cpu': ['FRONTEND','COMPUTE','DRIVES'],
+                'ops': ['FRONTEND'],
+                'ops_driver': ['FRONTEND'],
+                'ops_nfs': ['COMPUTE'],     # not sure about this one
+                'ssd': ['DRIVES']
+                }
+
         # schedule a bunch of data gather queries
         for category, stat_dict in self.get_commandlist().items():
+
+            category_nodes = []
+            #log.error(f"{cluster.name} category is: {category} {category_nodetypes[category]}")
+            for nodetype in category_nodetypes[category]:  # nodetype is FRONTEND, COMPUTE, DRIVES, MANAGEMENT
+                category_nodes += node_maps[nodetype]
+
+            #log.error(f"{cluster.name} cat nodes: {category} {category_nodes}")
+
+            query_nodes = list( set( category_nodes.copy() ) ) # make the list unique so we don't ask for the same data muliple times
+
             for stat, command in stat_dict.items():
-                try:
-                    thread_runner.new( self.call_api, (cluster, stat, category, command ) ) 
-                except:
-                    log.error( "gather(): error scheduling thread wekastat for cluster {}".format(str(cluster)) )
+                step = 100
+                for i in range(0, len(query_nodes), step):
+                    import copy
+                    newcmd = copy.deepcopy(command)                           # make sure to copy it
+                    newcmd["parms"]["node_ids"] = copy.deepcopy(query_nodes[i:i+step])     # make sure to copy it
+                    #log.error(f"{i}: {i+step}, {cluster.name} {query_nodes[i:i+step]}" )  # debugging
+                    #log.error(f"scheduling {cluster.name} {newcmd['parms']}" )
+                    try:
+                        thread_runner.new( self.call_api, (cluster, stat, category, newcmd ) ) 
+                        #thread_runner.new( self.call_api, (cluster, stat, category, command ) ) 
+                    except:
+                        log.error( "gather(): error scheduling thread wekastat for cluster {}".format(str(cluster)) )
 
         thread_runner.run()     # schedule the rest of the threads, wait for them
         del thread_runner

--- a/export/wekacluster.py
+++ b/export/wekacluster.py
@@ -132,7 +132,7 @@ class WekaCluster(object):
         host = self.hosts.reserve()
         api_return = None
         while host != None:
-            log.debug( "calling Weka API on cluster {}, host {}".format(self.name,host) )
+            log.debug( "calling Weka API on cluster {self.name}, host {host} {method} {parms}")
             try:
                 api_return = host.call_api( method, parms )
             except Exception as exc:
@@ -141,9 +141,8 @@ class WekaCluster(object):
                 self.hosts.remove(host)     # remove it from the hostlist iterable
                 host = self.hosts.reserve() # try another host; will return None if none left or failure
                 self.errors += 1
-                log.error( "cluster={}, error {} spawning command {} on host {}. Retrying on {}.".format(
-                        self.name, exc, str(method), last_hostname, str(host)) )
-                print(traceback.format_exc())
+                #log.error(f"cluster={self.name}, error {exc} spawning command {str(method)}{parms} on host {last_hostname}. Retrying on {str(host)}.")
+                #print(traceback.format_exc())
                 continue
 
             self.hosts.release(host)    # release it so it can be used for more queries

--- a/var_lib_grafana/dashboards/Weka_Cluster_Overview.json
+++ b/var_lib_grafana/dashboards/Weka_Cluster_Overview.json
@@ -15,7 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1607798252166,
+  "id": 5,
+  "iteration": 1608738857850,
   "links": [
     {
       "$$hashKey": "object:415",
@@ -421,6 +422,63 @@
       "type": "stat"
     },
     {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-purple",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 12,
+        "y": 1
+      },
+      "id": 104,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "7.3.4",
+      "targets": [
+        {
+          "expr": "weka_num_servers_total{cluster=\"$cluster\"} - weka_num_servers_active{cluster=\"$cluster\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Offline Servers",
+      "type": "stat"
+    },
+    {
       "cacheTimeout": null,
       "datasource": "$weka_datasource",
       "fieldConfig": {
@@ -460,9 +518,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 12,
+        "h": 3,
+        "w": 3,
+        "x": 14,
         "y": 1
       },
       "hideTimeOverride": true,
@@ -847,6 +905,59 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "Unprovisioned",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-purple",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 10,
+        "y": 3
+      },
+      "id": 103,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "7.3.4",
+      "targets": [
+        {
+          "expr": "weka_num_servers_total{cluster=\"$cluster\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Cluster Size",
       "type": "stat"
     },
     {
@@ -1845,1039 +1956,1040 @@
         "y": 12
       },
       "id": 63,
-      "panels": [],
-      "title": "Cluster-wide IO Statistics",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$weka_datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 9,
-        "x": 0,
-        "y": 13
-      },
-      "hiddenSeries": false,
-      "id": 41,
-      "interval": "1m",
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.3.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
+      "panels": [
         {
-          "expr": "weka_overview_activity_ops{cluster=\"$cluster\"}",
-          "interval": "",
-          "legendFormat": "{{cluster}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Operations per second, total",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:230",
-          "format": "iops",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "$$hashKey": "object:231",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$weka_datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 9,
-        "x": 9,
-        "y": 13
-      },
-      "hiddenSeries": false,
-      "id": 65,
-      "interval": "1m",
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.3.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "weka_overview_activity_read_bytespersec{cluster=\"$cluster\"} + weka_overview_activity_write_bytespersec{cluster=\"$cluster\"}",
-          "interval": "",
-          "legendFormat": "{{cluster}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Throughput per second, total",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "Bps",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$weka_datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 9,
-        "x": 0,
-        "y": 19
-      },
-      "hiddenSeries": false,
-      "id": 69,
-      "interval": "1m",
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.3.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "weka_overview_activity_write_iops{cluster=\"$cluster\"}",
-          "interval": "",
-          "legendFormat": "writes",
-          "refId": "A"
-        },
-        {
-          "expr": "weka_overview_activity_read_iops{cluster=\"$cluster\"}",
-          "interval": "",
-          "legendFormat": "reads",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Read vs Write IOPS, total",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "iops",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$weka_datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 9,
-        "x": 9,
-        "y": 19
-      },
-      "hiddenSeries": false,
-      "id": 66,
-      "interval": "1m",
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.3.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "weka_overview_activity_read_bytespersec{cluster=\"$cluster\"}",
-          "interval": "",
-          "legendFormat": "reads",
-          "refId": "A"
-        },
-        {
-          "expr": "weka_overview_activity_write_bytespersec{cluster=\"$cluster\"}",
-          "interval": "",
-          "legendFormat": "writes",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Read vs Write Bytes per second, total",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "Bps",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$weka_datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 9,
-        "x": 0,
-        "y": 25
-      },
-      "hiddenSeries": false,
-      "id": 76,
-      "interval": "1m",
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.3.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "weka_overview_activity_ops{cluster=\"$cluster\"} - weka_overview_activity_write_iops{cluster=\"$cluster\"} - weka_overview_activity_read_iops{cluster=\"$cluster\"}",
-          "interval": "",
-          "legendFormat": "metadata ops",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Metadata, total",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:1136",
-          "format": "iops",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "$$hashKey": "object:1137",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$weka_datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 9,
-        "x": 9,
-        "y": 25
-      },
-      "hiddenSeries": false,
-      "id": 68,
-      "interval": "1m",
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.3.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "weka_overview_activity_object_download_bytespersec{cluster=\"$cluster\"}",
-          "interval": "",
-          "legendFormat": "download",
-          "refId": "A"
-        },
-        {
-          "expr": "weka_overview_activity_object_upload_bytespersec{cluster=\"$cluster\"}",
-          "interval": "",
-          "legendFormat": "upload",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Download vs Upload Object Store Data Rate",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "iops",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$weka_datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 9,
-        "x": 0,
-        "y": 31
-      },
-      "hiddenSeries": false,
-      "id": 96,
-      "interval": "1m",
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.3.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"FILEOPEN_OPS\"})",
-          "interval": "",
-          "legendFormat": "open",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"CREATE_OPS\"})",
-          "interval": "",
-          "legendFormat": "create",
-          "refId": "B"
-        },
-        {
-          "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"FILECLOSE_OPS\"})",
-          "interval": "",
-          "legendFormat": "close",
-          "refId": "C"
-        },
-        {
-          "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"MKDIR_OPS\"})",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "D"
-        },
-        {
-          "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"READDIR_OPS\"})",
-          "interval": "",
-          "legendFormat": "read dir",
-          "refId": "E"
-        },
-        {
-          "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"REMOVE_OPS\"})",
-          "interval": "",
-          "legendFormat": "remove",
-          "refId": "F"
-        },
-        {
-          "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"RMDIR_OPS\"})",
-          "interval": "",
-          "legendFormat": "rmdir",
-          "refId": "G"
-        },
-        {
-          "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"UNLINK_OPS\"})",
-          "interval": "",
-          "legendFormat": "unlink",
-          "refId": "H"
-        },
-        {
-          "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"ACCESS_OPS\"})",
-          "interval": "",
-          "legendFormat": "access",
-          "refId": "I"
-        },
-        {
-          "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"COMMIT_OPS\"})",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "J"
-        },
-        {
-          "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"FLOCK_OPS\"})",
-          "interval": "",
-          "legendFormat": "flock",
-          "refId": "K"
-        },
-        {
-          "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"FSINFO_OPS\"})",
-          "interval": "",
-          "legendFormat": "fsinfo",
-          "refId": "L"
-        },
-        {
-          "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"GETATTR_OPS\"})",
-          "interval": "",
-          "legendFormat": "getattr",
-          "refId": "M"
-        },
-        {
-          "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"LINK_OPS\"})",
-          "interval": "",
-          "legendFormat": "link",
-          "refId": "N"
-        },
-        {
-          "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"MKNOD_OPS\"})",
-          "interval": "",
-          "legendFormat": "mknod",
-          "refId": "O"
-        },
-        {
-          "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"RENAME_OPS\"})",
-          "interval": "",
-          "legendFormat": "rename",
-          "refId": "P"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Metadata by operation",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:1136",
-          "format": "iops",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "$$hashKey": "object:1137",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$weka_datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 9,
-        "x": 9,
-        "y": 31
-      },
-      "hiddenSeries": false,
-      "id": 97,
-      "interval": "1m",
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.3.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum by (le) (weka_blocksize_bucket{cluster=\"$cluster\",category=\"ops_driver\",stat=\"READ_SIZES\"})",
-          "format": "heatmap",
-          "interval": "",
-          "legendFormat": "{{le}} reads",
-          "refId": "A"
-        },
-        {
-          "expr": "sum by (le) (weka_blocksize_bucket{cluster=\"$cluster\",category=\"ops_driver\",stat=\"WRITE_SIZES\"})",
-          "format": "heatmap",
-          "interval": "",
-          "legendFormat": "{{le}} writes",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "io blocksize distribution",
-      "tooltip": {
-        "shared": true,
-        "sort": 1,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:147",
-          "format": "iops",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "$$hashKey": "object:148",
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "cards": {
-        "cardPadding": null,
-        "cardRound": null
-      },
-      "color": {
-        "cardColor": "#b4ff00",
-        "colorScale": "sqrt",
-        "colorScheme": "interpolatePurples",
-        "exponent": 0.5,
-        "mode": "spectrum"
-      },
-      "dataFormat": "tsbuckets",
-      "datasource": "$weka_datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 9,
-        "x": 0,
-        "y": 37
-      },
-      "heatmap": {},
-      "hideZeroBuckets": false,
-      "highlightCards": true,
-      "id": 99,
-      "interval": "1m",
-      "legend": {
-        "show": true
-      },
-      "pluginVersion": "7.1.1",
-      "reverseYBuckets": false,
-      "targets": [
-        {
-          "expr": "sum by (le) (weka_blocksize_bucket{cluster=\"$cluster\",category=\"ops_driver\",stat=\"READ_SIZES\"})",
-          "format": "heatmap",
-          "interval": "",
-          "legendFormat": "{{le}} reads",
-          "refId": "A"
-        },
-        {
-          "expr": "sum by (le) (weka_blocksize_bucket{cluster=\"$cluster\",category=\"ops_driver\",stat=\"WRITE_SIZES\"})",
-          "format": "heatmap",
-          "interval": "",
-          "legendFormat": "{{le}} writes",
-          "refId": "B"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "io blocksize distribution heatmap",
-      "tooltip": {
-        "show": true,
-        "showHistogram": false
-      },
-      "type": "heatmap",
-      "xAxis": {
-        "show": true
-      },
-      "xBucketNumber": null,
-      "xBucketSize": null,
-      "yAxis": {
-        "decimals": null,
-        "format": "short",
-        "logBase": 1,
-        "max": null,
-        "min": null,
-        "show": true,
-        "splitFactor": null
-      },
-      "yBucketBound": "auto",
-      "yBucketNumber": null,
-      "yBucketSize": null
-    },
-    {
-      "datasource": "$weka_datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "purple",
-                "value": null
-              }
-            ]
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$weka_datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 6,
+            "w": 9,
+            "x": 0,
+            "y": 13
+          },
+          "hiddenSeries": false,
+          "id": 41,
+          "interval": "1m",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.3.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "weka_overview_activity_ops{cluster=\"$cluster\"}",
+              "interval": "",
+              "legendFormat": "{{cluster}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Operations per second, total",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:230",
+              "format": "iops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:231",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
           }
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 9,
-        "x": 9,
-        "y": 37
-      },
-      "id": 98,
-      "interval": "1m",
-      "options": {
-        "displayMode": "gradient",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "last"
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$weka_datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 6,
+            "w": 9,
+            "x": 9,
+            "y": 13
+          },
+          "hiddenSeries": false,
+          "id": 65,
+          "interval": "1m",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.3.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "weka_overview_activity_read_bytespersec{cluster=\"$cluster\"} + weka_overview_activity_write_bytespersec{cluster=\"$cluster\"}",
+              "interval": "",
+              "legendFormat": "{{cluster}}",
+              "refId": "A"
+            }
           ],
-          "fields": "",
-          "values": false
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Throughput per second, total",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "Bps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
-        "showUnfilled": true
-      },
-      "pluginVersion": "7.3.4",
-      "targets": [
         {
-          "expr": "sum by (le) (weka_blocksize_bucket{cluster=\"$cluster\",category=\"ops_driver\",stat=\"READ_SIZES\"})",
-          "format": "heatmap",
-          "interval": "",
-          "legendFormat": "{{le}} reads",
-          "refId": "A"
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$weka_datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 6,
+            "w": 9,
+            "x": 0,
+            "y": 19
+          },
+          "hiddenSeries": false,
+          "id": 69,
+          "interval": "1m",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.3.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "weka_overview_activity_write_iops{cluster=\"$cluster\"}",
+              "interval": "",
+              "legendFormat": "writes",
+              "refId": "A"
+            },
+            {
+              "expr": "weka_overview_activity_read_iops{cluster=\"$cluster\"}",
+              "interval": "",
+              "legendFormat": "reads",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Read vs Write IOPS, total",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "iops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
-          "expr": "sum by (le) (weka_blocksize_bucket{cluster=\"$cluster\",category=\"ops_driver\",stat=\"WRITE_SIZES\"})",
-          "format": "heatmap",
-          "interval": "",
-          "legendFormat": "{{le}} writes",
-          "refId": "B"
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$weka_datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 6,
+            "w": 9,
+            "x": 9,
+            "y": 19
+          },
+          "hiddenSeries": false,
+          "id": 66,
+          "interval": "1m",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.3.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "weka_overview_activity_read_bytespersec{cluster=\"$cluster\"}",
+              "interval": "",
+              "legendFormat": "reads",
+              "refId": "A"
+            },
+            {
+              "expr": "weka_overview_activity_write_bytespersec{cluster=\"$cluster\"}",
+              "interval": "",
+              "legendFormat": "writes",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Read vs Write Bytes per second, total",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "Bps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$weka_datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 6,
+            "w": 9,
+            "x": 0,
+            "y": 25
+          },
+          "hiddenSeries": false,
+          "id": 76,
+          "interval": "1m",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.3.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "weka_overview_activity_ops{cluster=\"$cluster\"} - weka_overview_activity_write_iops{cluster=\"$cluster\"} - weka_overview_activity_read_iops{cluster=\"$cluster\"}",
+              "interval": "",
+              "legendFormat": "metadata ops",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Metadata, total",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:1136",
+              "format": "iops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:1137",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$weka_datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 6,
+            "w": 9,
+            "x": 9,
+            "y": 25
+          },
+          "hiddenSeries": false,
+          "id": 68,
+          "interval": "1m",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.3.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "weka_overview_activity_object_download_bytespersec{cluster=\"$cluster\"}",
+              "interval": "",
+              "legendFormat": "download",
+              "refId": "A"
+            },
+            {
+              "expr": "weka_overview_activity_object_upload_bytespersec{cluster=\"$cluster\"}",
+              "interval": "",
+              "legendFormat": "upload",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Download vs Upload Object Store Data Rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "iops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$weka_datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 6,
+            "w": 9,
+            "x": 0,
+            "y": 31
+          },
+          "hiddenSeries": false,
+          "id": 96,
+          "interval": "1m",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.3.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"FILEOPEN_OPS\"})",
+              "interval": "",
+              "legendFormat": "open",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"CREATE_OPS\"})",
+              "interval": "",
+              "legendFormat": "create",
+              "refId": "B"
+            },
+            {
+              "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"FILECLOSE_OPS\"})",
+              "interval": "",
+              "legendFormat": "close",
+              "refId": "C"
+            },
+            {
+              "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"MKDIR_OPS\"})",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "D"
+            },
+            {
+              "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"READDIR_OPS\"})",
+              "interval": "",
+              "legendFormat": "read dir",
+              "refId": "E"
+            },
+            {
+              "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"REMOVE_OPS\"})",
+              "interval": "",
+              "legendFormat": "remove",
+              "refId": "F"
+            },
+            {
+              "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"RMDIR_OPS\"})",
+              "interval": "",
+              "legendFormat": "rmdir",
+              "refId": "G"
+            },
+            {
+              "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"UNLINK_OPS\"})",
+              "interval": "",
+              "legendFormat": "unlink",
+              "refId": "H"
+            },
+            {
+              "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"ACCESS_OPS\"})",
+              "interval": "",
+              "legendFormat": "access",
+              "refId": "I"
+            },
+            {
+              "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"COMMIT_OPS\"})",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "J"
+            },
+            {
+              "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"FLOCK_OPS\"})",
+              "interval": "",
+              "legendFormat": "flock",
+              "refId": "K"
+            },
+            {
+              "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"FSINFO_OPS\"})",
+              "interval": "",
+              "legendFormat": "fsinfo",
+              "refId": "L"
+            },
+            {
+              "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"GETATTR_OPS\"})",
+              "interval": "",
+              "legendFormat": "getattr",
+              "refId": "M"
+            },
+            {
+              "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"LINK_OPS\"})",
+              "interval": "",
+              "legendFormat": "link",
+              "refId": "N"
+            },
+            {
+              "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"MKNOD_OPS\"})",
+              "interval": "",
+              "legendFormat": "mknod",
+              "refId": "O"
+            },
+            {
+              "expr": "sum(weka_stats{cluster=\"$cluster\",stat=\"RENAME_OPS\"})",
+              "interval": "",
+              "legendFormat": "rename",
+              "refId": "P"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Metadata by operation",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:1136",
+              "format": "iops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:1137",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$weka_datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 6,
+            "w": 9,
+            "x": 9,
+            "y": 31
+          },
+          "hiddenSeries": false,
+          "id": 97,
+          "interval": "1m",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.3.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by (le) (weka_blocksize_bucket{cluster=\"$cluster\",category=\"ops_driver\",stat=\"READ_SIZES\"})",
+              "format": "heatmap",
+              "interval": "",
+              "legendFormat": "{{le}} reads",
+              "refId": "A"
+            },
+            {
+              "expr": "sum by (le) (weka_blocksize_bucket{cluster=\"$cluster\",category=\"ops_driver\",stat=\"WRITE_SIZES\"})",
+              "format": "heatmap",
+              "interval": "",
+              "legendFormat": "{{le}} writes",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "io blocksize distribution",
+          "tooltip": {
+            "shared": true,
+            "sort": 1,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:147",
+              "format": "iops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:148",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolatePurples",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": "$weka_datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 9,
+            "x": 0,
+            "y": 37
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 99,
+          "interval": "1m",
+          "legend": {
+            "show": true
+          },
+          "pluginVersion": "7.1.1",
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "sum by (le) (weka_blocksize_bucket{cluster=\"$cluster\",category=\"ops_driver\",stat=\"READ_SIZES\"})",
+              "format": "heatmap",
+              "interval": "",
+              "legendFormat": "{{le}} reads",
+              "refId": "A"
+            },
+            {
+              "expr": "sum by (le) (weka_blocksize_bucket{cluster=\"$cluster\",category=\"ops_driver\",stat=\"WRITE_SIZES\"})",
+              "format": "heatmap",
+              "interval": "",
+              "legendFormat": "{{le}} writes",
+              "refId": "B"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "io blocksize distribution heatmap",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "datasource": "$weka_datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "purple",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 9,
+            "x": 9,
+            "y": 37
+          },
+          "id": 98,
+          "interval": "1m",
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true
+          },
+          "pluginVersion": "7.3.4",
+          "targets": [
+            {
+              "expr": "sum by (le) (weka_blocksize_bucket{cluster=\"$cluster\",category=\"ops_driver\",stat=\"READ_SIZES\"})",
+              "format": "heatmap",
+              "interval": "",
+              "legendFormat": "{{le}} reads",
+              "refId": "A"
+            },
+            {
+              "expr": "sum by (le) (weka_blocksize_bucket{cluster=\"$cluster\",category=\"ops_driver\",stat=\"WRITE_SIZES\"})",
+              "format": "heatmap",
+              "interval": "",
+              "legendFormat": "{{le}} writes",
+              "refId": "B"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "io blocksize distribution (instant)",
+          "type": "bargauge"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "io blocksize distribution (instant)",
-      "type": "bargauge"
+      "title": "Cluster-wide IO Statistics",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -2886,7 +2998,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 13
       },
       "id": 16,
       "panels": [
@@ -3651,7 +3763,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 14
       },
       "id": 54,
       "panels": [
@@ -4509,7 +4621,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 15
       },
       "id": 78,
       "panels": [
@@ -4531,7 +4643,7 @@
             "h": 14,
             "w": 22,
             "x": 0,
-            "y": 115
+            "y": 16
           },
           "hiddenSeries": false,
           "id": 80,
@@ -4547,8 +4659,11 @@
           "lines": true,
           "linewidth": 1,
           "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
           "percentage": false,
-          "pluginVersion": "7.1.1",
+          "pluginVersion": "7.3.4",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4622,6 +4737,9 @@
     "list": [
       {
         "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "error": null,
         "hide": 0,
@@ -4640,6 +4758,9 @@
       {
         "allValue": null,
         "current": {
+          "selected": false,
+          "text": "A100_cluster",
+          "value": "A100_cluster"
         },
         "datasource": "$weka_datasource",
         "definition": "label_values(weka_info,cluster)",
@@ -4665,11 +4786,11 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "vweka1",
-          "value": "vweka1"
+          "text": "b10i",
+          "value": "b10i"
         },
         "datasource": "$weka_datasource",
-        "definition": "label_values(weka_stats{cluster=\"$cluster\"},host_name)",
+        "definition": "label_values(weka_stats{cluster=\"$cluster\",host_role=\"server\"},host_name)",
         "error": null,
         "hide": 2,
         "includeAll": false,
@@ -4677,7 +4798,7 @@
         "multi": false,
         "name": "gui_host",
         "options": [],
-        "query": "label_values(weka_stats{cluster=\"$cluster\"},host_name)",
+        "query": "label_values(weka_stats{cluster=\"$cluster\",host_role=\"server\"},host_name)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/var_lib_grafana/dashboards/Weka_Cluster_Overview.json
+++ b/var_lib_grafana/dashboards/Weka_Cluster_Overview.json
@@ -4737,9 +4737,6 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "Prometheus",
-          "value": "Prometheus"
         },
         "error": null,
         "hide": 0,
@@ -4758,9 +4755,6 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
-          "text": "A100_cluster",
-          "value": "A100_cluster"
         },
         "datasource": "$weka_datasource",
         "definition": "label_values(weka_info,cluster)",
@@ -4785,9 +4779,6 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
-          "text": "b10i",
-          "value": "b10i"
         },
         "datasource": "$weka_datasource",
         "definition": "label_values(weka_stats{cluster=\"$cluster\",host_role=\"server\"},host_name)",
@@ -4831,5 +4822,5 @@
   "timezone": "",
   "title": "Weka Cluster Overview",
   "uid": "WekaOverview",
-  "version": 1
+  "version": 2
 }

--- a/var_lib_grafana/dashboards/Weka_Exporter.json
+++ b/var_lib_grafana/dashboards/Weka_Exporter.json
@@ -421,9 +421,6 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "Prometheus",
-          "value": "Prometheus"
         },
         "error": null,
         "hide": 0,

--- a/var_lib_grafana/dashboards/Weka_Exporter.json
+++ b/var_lib_grafana/dashboards/Weka_Exporter.json
@@ -15,9 +15,108 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1607780928490,
+  "id": 6,
+  "iteration": 1608813753284,
   "links": [],
   "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 23,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total[5m])",
+          "interval": "",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Docker Cpu Seconds",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:76",
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:77",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
     {
       "aliasColors": {},
       "bars": false,
@@ -37,7 +136,7 @@
         "h": 10,
         "w": 23,
         "x": 0,
-        "y": 0
+        "y": 10
       },
       "hiddenSeries": false,
       "id": 5,
@@ -133,7 +232,7 @@
         "h": 11,
         "w": 23,
         "x": 0,
-        "y": 10
+        "y": 20
       },
       "hiddenSeries": false,
       "id": 2,
@@ -233,7 +332,7 @@
         "h": 10,
         "w": 23,
         "x": 0,
-        "y": 21
+        "y": 31
       },
       "hiddenSeries": false,
       "id": 6,
@@ -342,7 +441,7 @@
     ]
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {

--- a/var_lib_grafana/dashboards/Weka_Exporter.json
+++ b/var_lib_grafana/dashboards/Weka_Exporter.json
@@ -457,5 +457,5 @@
   "timezone": "",
   "title": "Weka Metrics Exporter Stats",
   "uid": "WekaExporter",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
Split queries so they ask for data for a subset of node-ids, rather than all; large clusters can have trouble returning all node-id data within the timeout period.